### PR TITLE
Added attributes 'correction' and 'observed' to afex_aov$anova_table

### DIFF
--- a/R/methods.afex_aov.R
+++ b/R/methods.afex_aov.R
@@ -101,6 +101,8 @@ anova.afex_aov <- function(object, es = afex_options("es_aov"), observed = NULL,
   if(is.null(p.adjust.method)) p.adjust.method <- ifelse(is.null(attr(object$anova_table, "p.adjust.method")), "none", attr(object$anova_table, "p.adjust.method"))
   anova_table[,"Pr(>F)"] <- p.adjust(anova_table[,"Pr(>F)"], method = p.adjust.method)
   attr(anova_table, "p.adjust.method") <- p.adjust.method
+  attr(anova_table, "correction") <- correction
+  attr(anova_table, "observed") <- if(!is.null(observed)) observed else "none"
   anova_table
 }
 

--- a/R/nice.R
+++ b/R/nice.R
@@ -81,8 +81,17 @@ nice <- function(object, ...) UseMethod("nice", object)
 #' @rdname nice
 #' @method nice afex_aov
 #' @export
-nice.afex_aov <- function(object, es = afex_options("es_aov"), observed = NULL, correction = afex_options("correction_aov"), MSE = TRUE, intercept = FALSE, sig.symbols = c(" +", " *", " **", " ***"), p.adjust.method = NULL, ...) { 
-  if(is.null(p.adjust.method)) p.adjust.method <- ifelse(is.null(attr(object$anova_table, "p.adjust.method")), "none", attr(object$anova_table, "p.adjust.method"))
+nice.afex_aov <- function(object, es = NULL, observed = attr(object$anova_table, "observed"), correction = attr(object$anova_table, "correction"), MSE = NULL, intercept = NULL, p.adjust.method = attr(object$anova_table, "p.adjust.method"), sig.symbols = c(" +", " *", " **", " ***"), ...) { 
+  if(is.null(es)) { # Defaults to afex_options("es") because of default set in anova.afex_aov
+    es <- c("pes", "ges")[c("pes", "ges") %in% colnames(object$anova_table)]
+  }
+  if(is.null(MSE)) { # Defaults to TRUE because of default set in anova.afex_aov
+    MSE <- "MSE" %in% colnames(object$anova_table)
+  }
+  if(is.null(intercept)) { # Defaults to FALSE because of default set in anova.afex_aov
+    intercept <- "(Intercept)" %in% rownames(object$anova_table)
+  }
+  
   anova_table <- as.data.frame(anova(object, es = es, observed = observed, correction = correction, MSE = MSE, intercept = intercept, p.adjust.method = p.adjust.method))
   nice.anova(anova_table, MSE = MSE, intercept = intercept, sig.symbols = sig.symbols)
 }

--- a/tests/testthat/test-aov_car-structural.R
+++ b/tests/testthat/test-aov_car-structural.R
@@ -40,3 +40,24 @@ test_that("return='aov' works", {
   expect_equal(summary(orig1$Anova, multivariate = FALSE), summary(positive3$Anova, multivariate = FALSE))
   expect_equal(summary(orig1$aov), summary(positive3$aov))
 })
+
+test_that("anova_table attributes", {
+  data(md_12.1)
+  no_attr <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), anova_table=list(correction = "none"))
+  
+  expect_that(attr(no_attr$anova_table, "correction"), equals("none"))
+  expect_that(attr(no_attr$anova_table, "p.adjust.method"), equals("none"))
+  expect_that(attr(no_attr$anova_table, "observed"), equals("none"))
+  
+  all_attr <- suppressWarnings(aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), observed = "angle", anova_table=list(correction = "HF", p.adjust.method = "bonferroni")))
+  
+  expect_that(attr(all_attr$anova_table, "correction"), equals("HF"))
+  expect_that(attr(all_attr$anova_table, "p.adjust.method"), equals("bonferroni"))
+  expect_that(attr(all_attr$anova_table, "observed"), equals("angle"))
+  
+  added_attr <- suppressWarnings(nice(no_attr, correction = "HF", p.adjust = "bonferroni", observed = "angle"))
+  expect_that(nice(all_attr$anova_table), is_identical_to(added_attr))
+  
+  reset_attr <- nice(no_attr, correction = "none", p.adjust = "none", observed = NULL)
+  expect_that(nice(no_attr$anova_table), is_identical_to(reset_attr))
+})


### PR DESCRIPTION
Hi Henrik,

as I suggested, I have added the attributes `correction` and `observed` to `anova_table` objects. The parameters of `nice.afex_aov()` now default to the parameters set when calling `afex_aov()`, which again defaults to the options set in `afex_options()` (default of `anova.afex_aov()`). I have added some tests in `test-acv-car-structural.R`. These changes resolve #9.

Let me know what you think.