### PR TITLE
Set anova_table attribute "correction" to "none" in between subject anova

### DIFF
--- a/R/methods.afex_aov.R
+++ b/R/methods.afex_aov.R
@@ -102,7 +102,7 @@ anova.afex_aov <- function(object, es = afex_options("es_aov"), observed = NULL,
   p_adj_heading <- if(p.adjust.method != "none") paste0(", ", p.adjust.method, "-adjusted") else NULL
   attr(anova_table, "heading") <- c(paste0("Anova Table (Type ", attr(object, "type"), " tests", p_adj_heading, ")\n"), paste("Response:", attr(object, "dv")))
   attr(anova_table, "p.adjust.method") <- p.adjust.method
-  attr(anova_table, "correction") <- correction
+  attr(anova_table, "correction") <- if(length(attr(object, "within")) > 0) correction else "none"
   attr(anova_table, "observed") <- if(!is.null(observed) & length(observed) > 0) observed else character(0)
   anova_table
 }

--- a/tests/testthat/test-aov_car-structural.R
+++ b/tests/testthat/test-aov_car-structural.R
@@ -74,4 +74,9 @@ test_that("anova_table attributes", {
   attr(old_afex_object$anova_table, "correction") <- NULL
   attr(old_afex_object$anova_table, "p.adjust.method") <- NULL
   expect_that(nice(old_afex_object), is_identical_to(nice(default_options)))
+  
+  # Test if sphericity correction is set to "none" in the absence of within-subject factors
+  data(obk.long)
+  between_anova <- suppressWarnings(aov_car(value ~ treatment * gender + Error(id), data = obk.long))
+  expect_that(attr(between_anova$anova_table, "correction"), equals("none"))
 })


### PR DESCRIPTION
Hi Henrik,

this pull request ensures that the `anova_table` attribute `correction` is set to `"none"` when purely between subject designs are analyzed. This resolves the issue that `print.nice_table()` currently may claims that a sphericity correction has been applied in between subject ANOVA. Sorry for missing this the first time.

Best regards,
Frederik