### PR TITLE
Bug fixes

### DIFF
--- a/R/aov_car.R
+++ b/R/aov_car.R
@@ -38,7 +38,7 @@
 #' @param print.formula \code{aov_ez} and \code{aov_4} are wrapper for \code{aov_car}. This boolean argument indicates whether the formula in the call to \code{car.aov} should be printed. 
 #' @param return What should be returned? The default is given by \code{afex_options("return_aov")}, which is initially \code{"afex_aov"}, returning an S3 object of class \code{afex_aov} for which various \link[=afex_aov-methods]{methods} exist (see there and below for more details). To avoid the (potentially costly) computation via \code{aov} set \code{return} to \code{"nice"} in which case only the nice ANOVA table is returned (produced by \code{\link{nice}}, this was the previous default return value). Other values are currently still supported for backward compatibility.
 # Possible values are \code{c("Anova", "lm", "data", "nice", "full", "all", "univariate", "marginal", "aov")} (possibly abbreviated). 
-#' @param anova_table \code{list} of further arguments passed to function producing the ANOVA table.  Arguments such as \code{es} (effect size) or \code{correction}  are passed to either \code{anova.afex_aov} or \code{nice}. Note that those settings can also be changed once an object of class \code{afex_aov} is created by invoking the \code{anova} method directly.
+#' @param anova_table \code{list} of further arguments passed to function producing the ANOVA table.  Arguments such as \code{es} (effect size) or \code{correction}  are passed to either \code{anova.afex_aov} or \code{nice}. \code {sig.symbols} is currently ignored. Note that those settings can also be changed once an object of class \code{afex_aov} is created by invoking the \code{anova} method directly.
 #' @param ... Further arguments passed to \code{fun.aggregate}.
 #'
 #' @return \code{aov_car}, \code{aov_4}, and \code{aov_ez} are wrappers for \code{\link[car]{Anova}} and \code{\link{aov}}, the return value is dependent on the \code{return} argument. Per default, an S3 object of class \code{"afex_aov"} is returned containing the following slots: 
@@ -351,6 +351,7 @@ aov_car <- function(formula, data, fun.aggregate = NULL, type = afex_options("ty
     attr(afex_aov, "within") <- within
     attr(afex_aov, "between") <- between
     attr(afex_aov, "type") <- type
+    afex_aov$anova_table <- do.call("anova", args = c(object = list(afex_aov), observed = list(observed), anova_table))
     #afex_aov$anova_table <- do.call("anova", args = c(object = list(afex_aov), observed = list(observed), args.return))
     return(do.call("nice", args = c(object = list(afex_aov), observed = list(observed), anova_table)))
   }

--- a/R/methods.afex_aov.R
+++ b/R/methods.afex_aov.R
@@ -102,7 +102,9 @@ anova.afex_aov <- function(object, es = afex_options("es_aov"), observed = NULL,
   p_adj_heading <- if(p.adjust.method != "none") paste0(", ", p.adjust.method, "-adjusted") else NULL
   attr(anova_table, "heading") <- c(paste0("Anova Table (Type ", attr(object, "type"), " tests", p_adj_heading, ")\n"), paste("Response:", attr(object, "dv")))
   attr(anova_table, "p.adjust.method") <- p.adjust.method
-  attr(anova_table, "correction") <- if(length(attr(object, "within")) > 0) correction else "none"
+  attr(anova_table, "correction") <- if(length(attr(object, "within")) > 0 && any(sapply(object$data$long[, attr(object, "within"), drop = FALSE], nlevels) > 2)) correction else "none"
+  
+  
   attr(anova_table, "observed") <- if(!is.null(observed) & length(observed) > 0) observed else character(0)
   anova_table
 }

--- a/R/nice.R
+++ b/R/nice.R
@@ -97,7 +97,14 @@ nice.afex_aov <- function(object, es = NULL, observed = attr(object$anova_table,
 #' @rdname nice
 #' @method nice anova
 #' @export
-nice.anova <- function(object, MSE = TRUE, intercept = FALSE, sig.symbols = c(" +", " *", " **", " ***"), ...) {
+nice.anova <- function(object, MSE = NULL, intercept = NULL, sig.symbols = c(" +", " *", " **", " ***"), ...) {
+  if(is.null(MSE)) { # Defaults to TRUE because of default set in anova.afex_aov
+    MSE <- "MSE" %in% colnames(object)
+  }
+  if(is.null(intercept)) { # Defaults to FALSE because of default set in anova.afex_aov
+    intercept <- "(Intercept)" %in% rownames(object)
+  }
+  
   # internal functions:
   is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
   make.fs <- function(anova, symbols) {
@@ -111,7 +118,7 @@ nice.anova <- function(object, MSE = TRUE, intercept = FALSE, sig.symbols = c(" 
   symbols.use <-  c(" +", " *", " **", " ***")
   symbols.use[seq_along(sig.symbols)] <- sig.symbols
   df.out <- data.frame(Effect = row.names(anova_table), df = anova_table[,"df"], stringsAsFactors = FALSE)
-  if (!is.null(anova_table$MSE)) df.out <- cbind(df.out, data.frame(MSE = formatC(anova_table[,"MSE"], digits = 2, format = "f"), stringsAsFactors = FALSE))  
+  if (MSE) df.out <- cbind(df.out, data.frame(MSE = formatC(anova_table[,"MSE"], digits = 2, format = "f"), stringsAsFactors = FALSE))  
   df.out <- cbind(df.out, data.frame(F = make.fs(anova_table, symbols.use), stringsAsFactors = FALSE))
   if (!is.null(anova_table$ges)) df.out$ges <- round_ps(anova_table$ges)
   if (!is.null(anova_table$pes)) df.out$pes <- round_ps(anova_table$pes)

--- a/tests/testthat/test-aov_car-structural.R
+++ b/tests/testthat/test-aov_car-structural.R
@@ -63,7 +63,6 @@ test_that("anova_table attributes", {
   expect_that(suppressWarnings(nice(all_attr)), is_identical_to(added_attr))
   expect_that(nice(all_attr$anova_table), is_identical_to(added_attr))
   
-  
   reset_attr <- nice(no_attr, correction = "none", p.adjust = "none", observed = NULL)
   expect_that(nice(no_attr), is_identical_to(reset_attr))
   expect_that(nice(no_attr$anova_table), is_identical_to(reset_attr))
@@ -75,8 +74,19 @@ test_that("anova_table attributes", {
   attr(old_afex_object$anova_table, "p.adjust.method") <- NULL
   expect_that(nice(old_afex_object), is_identical_to(nice(default_options)))
   
-  # Test if sphericity correction is set to "none" in the absence of within-subject factors
+  # Test if sphericity correction is set to "none" in the absence of within-subject factors or if within-subject factors have only two levels
   data(obk.long)
   between_anova <- suppressWarnings(aov_car(value ~ treatment * gender + Error(id), data = obk.long))
   expect_that(attr(between_anova$anova_table, "correction"), equals("none"))
+  
+  obk.long <- droplevels(obk.long[obk.long$phase %in% c("post","pre"),])
+  two_level_anova <- suppressWarnings(aov_ez("id", "value", obk.long, between = c("treatment"), within = c("phase")))
+  expect_that(attr(two_level_anova$anova_table, "correction"), equals("none"))
+  
+  more_levels_anova <- aov_ez("id", "value", obk.long, between = c("treatment"), within = c("phase", "hour"))
+  expect_that(attr(more_levels_anova$anova_table, "correction"), equals("GG"))
+  
+  obk.long <- droplevels(obk.long[obk.long$hour %in% c("1","2"),])
+  two_levels_anova <- aov_ez("id", "value", obk.long, between = c("treatment"), within = c("phase", "hour"))
+  expect_that(attr(two_levels_anova$anova_table, "correction"), equals("none"))
 })

--- a/tests/testthat/test-aov_car-structural.R
+++ b/tests/testthat/test-aov_car-structural.R
@@ -67,6 +67,18 @@ test_that("anova_table attributes", {
   expect_that(nice(no_attr), is_identical_to(reset_attr))
   expect_that(nice(no_attr$anova_table), is_identical_to(reset_attr))
   
+  intercept_test <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), anova_table = list(intercept = TRUE))
+  expect_output(intercept_test, "(Intercept)")
+  
+  mse_test <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), anova_table = list(MSE = FALSE))
+  expect_null(mse_test$anova_table$MSE)
+  expect_output(nice(mse_test, MSE = TRUE), "MSE")
+  
+  symbol_test <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), anova_table = list(sig.symbols = c(" ", " a", " aa", " aaa")), return = "nice")
+  expect_output(symbol_test, "aaa")
+  symbol_test <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), anova_table = list(sig.symbols = c(" ", " a", " aa", " aaa")))
+  expect_output(symbol_test, "aaa")
+  
   # Test support for old afex objects
   old_afex_object <- default_options <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"))
   attr(old_afex_object$anova_table, "observed") <- NULL


### PR DESCRIPTION
Hi Henrik,

as discussed via e-mail I have [fixed](https://github.com/singmann/afex/compare/master...crsh:master#diff-8a5b7064d43cd65c7edc1ad0ac3b6f89R105) the bug that the `correction` attribute of `anova_table` was incorrectly set to `GG` by default when there was no within-subjects factor with more than two levels (I also added tests for this).

In the process I found two other small bugs:
1. The `intercept` option passed in the `anova_table`-list in `aov_car()` was ignored. The passed option is now used as expected.
2. I'm not exactly sure why this was the case, but `return = "nice"` threw an error complaining that `es` was not set correctly. I fixed this issue as well by adding [a line](https://github.com/singmann/afex/compare/master...crsh:master#diff-e88193a056961d33007d7390f33df59eR354) in `aov_car.R`. Does this make sense to you?

Finally, in this pull request I have left another minor issue untouched. Setting `sig.symbols` in `anova_table` in a call to `aov_car()` is currently ignored (I have added this fact to the documentation). I wanted to run the possible solution for this by you first. But I'll open an issue to discuss this.