### PR TITLE
Change ems() 'random' parameter default argument from NULL to ""

### DIFF
--- a/R/ems.R
+++ b/R/ems.R
@@ -21,7 +21,7 @@
 #' @export
 
 
-ems <- function(design, nested=NULL, random=NULL){
+ems <- function(design, nested=NULL, random=""){
   # modify design formula based on nested factors specified
   if(!is.null(nested)){
     terms <- attr(terms(design), "term.labels")

--- a/man/ems.Rd
+++ b/man/ems.Rd
@@ -6,7 +6,7 @@
  
  Implements the Cornfield-Tukey algorithm for deriving the expected values of the mean squares for factorial designs.}
 \usage{
-ems(design, nested = NULL, random = NULL)
+ems(design, nested = NULL, random = "")
 }
 \arguments{
 \item{design}{A \code{formula} object specifying the factors in the design (except residual error, which is always implicitly included). The left hand side of the \code{~} is the symbol that will be used to denote the number of replications per lowest-level factor combination (I usually use "r" or "n"). The right hand side should include all fixed and random factors separated by \code{*}. Factor names should be single letters.}


### PR DESCRIPTION
The ems() function does not currently behave correctly when the user does
not supply any arguments to the 'random' parameter. The default argument is
NULL. The intention is that this will be interpreted as all factors being
fixed. Instead, it is interpreted as all factors being random. I had not
noticed this before because I pretty much only use ems() as part of the
underlying machinery to my PANGEA shiny app, and the way the function is
called there, an argument is always explicitly passed to 'random' (i.e., if
the user selects all factors fixed, ems is called with random="", rather than
omitting the random parameter). Anyway, the solution appears to be simple:
just change the default argument from NULL to "". That is what this commit
does. It appears to work fine now with this change.