### PR TITLE
Adds sig_symbol support to mixed()-methods.

### DIFF
--- a/R/aov_car.R
+++ b/R/aov_car.R
@@ -38,7 +38,7 @@
 #' @param print.formula \code{aov_ez} and \code{aov_4} are wrapper for \code{aov_car}. This boolean argument indicates whether the formula in the call to \code{car.aov} should be printed. 
 #' @param return What should be returned? The default is given by \code{afex_options("return_aov")}, which is initially \code{"afex_aov"}, returning an S3 object of class \code{afex_aov} for which various \link[=afex_aov-methods]{methods} exist (see there and below for more details). To avoid the (potentially costly) computation via \code{aov} set \code{return} to \code{"nice"} in which case only the nice ANOVA table is returned (produced by \code{\link{nice}}, this was the previous default return value). Other values are currently still supported for backward compatibility.
 # Possible values are \code{c("Anova", "lm", "data", "nice", "full", "all", "univariate", "marginal", "aov")} (possibly abbreviated). 
-#' @param anova_table \code{list} of further arguments passed to function producing the ANOVA table.  Arguments such as \code{es} (effect size) or \code{correction}  are passed to either \code{anova.afex_aov} or \code{nice}. \code{sig_symbols} is currently ignored. Note that those settings can also be changed once an object of class \code{afex_aov} is created by invoking the \code{anova} method directly.
+#' @param anova_table \code{list} of further arguments passed to function producing the ANOVA table.  Arguments such as \code{es} (effect size) or \code{correction}  are passed to either \code{anova.afex_aov} or \code{nice}. Note that those settings can also be changed once an object of class \code{afex_aov} is created by invoking the \code{anova} method directly.
 #' @param ... Further arguments passed to \code{fun_aggregate}.
 #'
 #' @return \code{aov_car}, \code{aov_4}, and \code{aov_ez} are wrappers for \code{\link[car]{Anova}} and \code{\link{aov}}, the return value is dependent on the \code{return} argument. Per default, an S3 object of class \code{"afex_aov"} is returned containing the following slots: 
@@ -141,9 +141,6 @@
 #' 
 #' @encoding UTF-8
 #'
-
-
-
 
 aov_car <- function(formula, data, fun_aggregate = NULL, type = afex_options("type"), factorize = afex_options("factorize"), check_contrasts = afex_options("check_contrasts"), return = afex_options("return_aov"), observed = NULL, anova_table = list(), ...) {
   return <- match.arg(return, c("Anova", "lm", "data", "nice", "afex_aov", "univariate", "marginal", "aov"))

--- a/R/methods.afex_aov.R
+++ b/R/methods.afex_aov.R
@@ -33,7 +33,7 @@ NULL
 #' @inheritParams nice
 #' @method anova afex_aov
 #' @export
-anova.afex_aov <- function(object, es = afex_options("es_aov"), observed = NULL, correction = afex_options("correction_aov"), MSE = TRUE, intercept = FALSE, p_adjust_method = NULL, sig_symbols = afex_options("sig_symbols"), ...) {
+anova.afex_aov <- function(object, es = afex_options("es_aov"), observed = NULL, correction = afex_options("correction_aov"), MSE = TRUE, intercept = FALSE, p_adjust_method = NULL, sig_symbols = attr(object$anova_table, "sig_symbols"), ...) {
   # internal functions:
   # check arguments
   dots <- list(...)
@@ -124,17 +124,6 @@ anova.afex_aov <- function(object, es = afex_options("es_aov"), observed = NULL,
 print.afex_aov <- function(x, ...) {
   out <- nice(x$anova_table, ...)
   print(out)
-  if (!is.null(attr(x$anova_table, "sig_symbols"))) {
-    sleg <- attr(symnum(0, cutpoints = c(0, 0.001, 0.01, 0.05, 0.1, 1), 
-                        symbols = rev(c(" " ,stringr::str_trim(attr(x$anova_table, "sig_symbols"))))), "legend")
-    width <- getOption("width")
-    
-    if(width < nchar(sleg)) {
-      sleg <- strwrap(sleg, width = width - 2, prefix = "  ")
-    } 
-    
-    cat("---\nSignif. codes:  ", sleg, sep = "", fill = getOption("width") + 4 + max(nchar(sleg, "bytes") - nchar(sleg)))
-  }
   invisible(out)
 }
 

--- a/R/mixed.R
+++ b/R/mixed.R
@@ -675,7 +675,7 @@ summary.mixed <- function(object, ...) {
 
 #' @method anova mixed
 #' @export
-anova.mixed <- function(object, sig_symbols = attr(object$anova_table, "sig_symbols"), ..., refit = FALSE) {
+anova.mixed <- function(object, ..., sig_symbols = attr(object$anova_table, "sig_symbols"), refit = FALSE) {
   mCall <- match.call(expand.dots = TRUE)
   full_model_name <- names(object)[[2]]
   dots <- list(...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,3 +51,19 @@ decomposeTerm <- function(term) {
 
     components
 }
+
+
+print_legend <- function(x) {
+  sig_symbols <- as.character(attr(x, "sig_symbols"))
+  if(length(sig_symbols) > 0 & !all(sig_symbols == rep("", 4))) {
+    sleg <- attr(stats::symnum(0, cutpoints = c(0, 0.001, 0.01, 0.05, 0.1, 1), 
+                               symbols = rev(c(" " , stringr::str_trim(sig_symbols)))), "legend")
+    width <- getOption("width")
+    
+    if(width < nchar(sleg)) {
+      sleg <- strwrap(sleg, width = width - 2, prefix = "  ")
+    } 
+    
+    cat("---\nSignif. codes:  ", sleg, sep = "", fill = getOption("width") + 4 + max(nchar(sleg, "bytes") - nchar(sleg)))
+  }
+}

--- a/tests/testthat/test-aov_car-structural.R
+++ b/tests/testthat/test-aov_car-structural.R
@@ -76,8 +76,15 @@ test_that("anova_table attributes", {
   
   symbol_test <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), anova_table = list(sig_symbols = c(" ", " a", " aa", " aaa")), return = "nice")
   expect_output(print(symbol_test), "aaa")
+  
   symbol_test <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"), anova_table = list(sig_symbols = c(" ", " a", " aa", " aaa")))
-  #expect_output(print(symbol_test), "aaa")
+  expect_output(print(symbol_test), "aaa")
+  
+  new_symbols <- c(" ", " b", " bb", " bbb")
+  symbol_test <- anova(symbol_test, sig_symbols = c(" ", " b", " bb", " bbb"))
+  expect_identical(attr(symbol_test, "sig_symbols"), new_symbols)
+  expect_output(print(nice(symbol_test)), "bbb")
+  
   
   # Test support for old afex objects
   old_afex_object <- default_options <- aov_ez("id", "rt", md_12.1, within = c("angle", "noise"))

--- a/tests/testthat/test-mixed-structure.R
+++ b/tests/testthat/test-mixed-structure.R
@@ -288,7 +288,7 @@ test_that("anova_table attributes", {
   
   symbol_test <- mixed(value ~ treatment * phase + (1|id), obk.long, sig_symbols = c("", "a", "aa", "aaa"))
   expect_output(print(symbol_test), "aaa")
-  expect_output(print(nice(mixed1, sig_symbols = c("", "b", "bb", "bbb"))), "bbb")
+  expect_output(print(nice(symbol_test, sig_symbols = c("", "b", "bb", "bbb"))), "bbb")
   
   new_symbols <- c(" ", " b", " bb", " bbb")
   symbol_test <- anova(symbol_test, sig_symbols = c(" ", " b", " bb", " bbb"))

--- a/tests/testthat/test-mixed-structure.R
+++ b/tests/testthat/test-mixed-structure.R
@@ -279,3 +279,24 @@ test_that("mixed all_fit = TRUE works with new (KR) methods", {
   expect_named(attr(sk2_aff_b2, "all_fit_selected"), "full_model")
   expect_false(is.null(attr(sk2_aff_b2, "all_fit_logLik")))
 })
+
+
+test_that("anova_table attributes", {
+  data(obk.long)
+  symbol_test <- mixed(value ~ treatment * phase + (1|id), obk.long, sig_symbols = c("", "a", "aa", "aaa"), return = "nice")
+  expect_output(print(symbol_test), "aaa")
+  
+  symbol_test <- mixed(value ~ treatment * phase + (1|id), obk.long, sig_symbols = c("", "a", "aa", "aaa"))
+  expect_output(print(symbol_test), "aaa")
+  expect_output(print(nice(mixed1, sig_symbols = c("", "b", "bb", "bbb"))), "bbb")
+  
+  new_symbols <- c(" ", " b", " bb", " bbb")
+  symbol_test <- anova(symbol_test, sig_symbols = c(" ", " b", " bb", " bbb"))
+  expect_identical(attr(symbol_test, "sig_symbols"), new_symbols)
+  expect_output(print(nice(symbol_test)), "bbb")
+  
+  # Test support for old afex objects
+  old_afex_object <- default_options <- mixed(value ~ treatment * phase + (1|id), obk.long)
+  attr(old_afex_object$anova_table, "sig_symbols") <- NULL
+  expect_that(nice(old_afex_object), is_identical_to(nice(default_options)))
+})


### PR DESCRIPTION
Hi Henrik,

this pull request adds the support for sig_symbols to mixed() and related methods as discussed in #17.

Also, it
- adds unit tests for aov_car() and mixed()
- adds documentation updates
- changes default of nice.mixed() and anova.afex_aov() to sig_symbols-attribute of object

Let me know what you think.