### PR TITLE
Make sure the idata data frame always holds a factor variable

### DIFF
--- a/R/aov_car.R
+++ b/R/aov_car.R
@@ -411,7 +411,7 @@ aov_car <- function(formula,
       within.levels <- lapply(lapply(data[,within], levels), factor)
       idata <- rev(expand.grid(rev(within.levels)))
     } else {
-      idata <- data.frame(levels(data[,within]))
+      idata <- data.frame(levels(data[,within]), stringsAsFactors = TRUE)
       colnames(idata) <- within
     }
     tmp.lm <- do.call(


### PR DESCRIPTION
If a user has the `stringsAsFactors` global option set to `FALSE`, and attempts to use `aov_car` or `aov_ez` to perform a repeated measures ANOVA with a single within-subject factor, then the `idata` data frame will hold a character vector instead of a factor. As a consequence, a contrast matrix for that variable fails to be created. The following example:

```r
library(afex)
data(obk.long, package = "afex")
obk_anova <- afex::aov_car(value ~ Error(id/hour),
                           data = obk.long)
traceback()
```
reveals the error

```
6: stop("contrasts apply only to factors")
5: `contrasts<-`(`*tmp*`, value = if (is.ordered(idata[, i])) icontrasts[2] else icontrasts[1])
4: Anova.III.mlm(mod, SSPE, error.df, idata, idesign, icontrasts, 
       imatrix, test.statistic, ...)
3: Anova.mlm(tmp.lm, idata = idata, idesign = as.formula(str_c("~", 
       rh3)), type = type)
2: Anova(tmp.lm, idata = idata, idesign = as.formula(str_c("~", 
       rh3)), type = type)
1: afex::aov_car(value ~ Error(id/hour), data = obk.long, anova_table = list(correction = "none"))
```

If I understand correctly, the `idata` data frame should *always* contain factor variable(s), so including the `stringsAsFactors = TRUE` argument to `data.frame` fixes the issue.

My `sessionInfo()` from running the above example is below.

```
R version 3.4.0 (2017-04-21)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 7 x64 (build 7601) Service Pack 1

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252   
[3] LC_MONETARY=English_United States.1252 LC_NUMERIC=C                          
[5] LC_TIME=English_United States.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] afex_0.19-1   emmeans_1.1   lme4_1.1-14   Matrix_1.2-11

loaded via a namespace (and not attached):
 [1] tidyr_0.7.2         splines_3.4.0       Formula_1.2-2       assertthat_0.2.0   
 [5] stats4_3.4.0        latticeExtra_0.6-28 coin_1.2-1          yaml_2.1.14        
 [9] backports_1.1.1     lattice_0.20-35     quantreg_5.34       glue_1.2.0         
[13] digest_0.6.12       RColorBrewer_1.1-2  checkmate_1.8.5     minqa_1.2.4        
[17] colorspace_1.3-2    sandwich_2.4-0      htmltools_0.3.6     plyr_1.8.4         
[21] pkgconfig_2.0.1     SparseM_1.77        purrr_0.2.4         xtable_1.8-2       
[25] mvtnorm_1.0-6       scales_0.5.0        MatrixModels_0.4-1  htmlTable_1.11.0   
[29] tibble_1.3.4        mgcv_1.8-17         car_2.1-6           ggplot2_2.2.1      
[33] TH.data_1.0-8       nnet_7.3-12         lazyeval_0.2.1      pbkrtest_0.4-7     
[37] survival_2.41-3     magrittr_1.5        estimability_1.2    nlme_3.1-131       
[41] MASS_7.3-47         foreign_0.8-69      tools_3.4.0         data.table_1.10.4-3
[45] multcomp_1.4-8      stringr_1.2.0       munsell_0.4.3       cluster_2.0.6      
[49] bindrcpp_0.2        compiler_3.4.0      rlang_0.1.4         grid_3.4.0         
[53] nloptr_1.0.4        rstudioapi_0.7      htmlwidgets_0.9     base64enc_0.1-3    
[57] gtable_0.2.0        codetools_0.2-15    lmerTest_2.0-33     reshape2_1.4.3     
[61] R6_2.2.2            gridExtra_2.3       zoo_1.8-0           knitr_1.17         
[65] dplyr_0.7.4         bindr_0.1           Hmisc_4.0-3         modeltools_0.2-21  
[69] stringi_1.1.6       parallel_3.4.0      Rcpp_0.12.14        rpart_4.1-11       
[73] acepack_1.4.1       coda_0.19-1
```