### PR TITLE
Added support for transformed response to aov_car

### DIFF
--- a/R/aov_car.R
+++ b/R/aov_car.R
@@ -148,7 +148,6 @@
 #' 
 #' @encoding UTF-8
 #'
-
 aov_car <- function(formula, 
                     data, 
                     fun_aggregate = NULL, 

--- a/R/aov_car.R
+++ b/R/aov_car.R
@@ -32,6 +32,11 @@
 #' @param formula A formula specifying the ANOVA model similar to \code{\link{aov}} (for \code{aov_car} or similar to \code{lme4:lmer} for \code{aov_4}). Should include an error term (i.e., \code{Error(id/...)} for \code{aov_car} or \code{(...|id)} for \code{aov_4}). Note that the within-subject factors do not need to be outside the Error term (this contrasts with \code{aov}). See Details.
 #' @param data A \code{data.frame} containing the data. Mandatory.
 #' @param fun_aggregate The function for aggregating the data before running the ANOVA if there is more than one observation per individual and cell of the design. The default \code{NULL} issues a warning if aggregation is necessary and uses \code{\link{mean}}. Pass \code{mean} directly to avoid the warning.
+#' @param transformation In \code{aov_ez}, a \code{character} vector (of length
+#'   1) indicating the name of a transformation to apply to \code{dv} before
+#'   fitting the model. If missing, no transformation is applied. In
+#'   \code{aov_car} and \code{aov_4}, a response transformation may be
+#'   incorporated in the left-hand side of \code{formula}.
 #' @param type The type of sums of squares for the ANOVA. The default is given by \code{afex_options("type")}, which is \strong{initially set to 3}. Passed to \code{\link[car]{Anova}}. Possible values are \code{"II"}, \code{"III"}, \code{2}, or \code{3}.
 #' @param factorize logical. Should between subject factors be factorized (with note) before running the analysis. The default is given by \code{afex_options("factorize")}, which is initially \code{TRUE}. If one wants to run an ANCOVA, this needs to be set to \code{FALSE} (in which case centering on 0 is checked on numeric variables).
 #' @param check_contrasts \code{logical}. Should contrasts for between-subject factors be checked and (if necessary) changed to be \code{"contr.sum"}. See details. The default is given by \code{afex_options("check_contrasts")}, which is initially \code{TRUE}.
@@ -583,6 +588,7 @@ aov_ez <- function(id,
                    covariate = NULL, 
                    observed = NULL, 
                    fun_aggregate = NULL, 
+                   transformation,
                    type = afex_options("type"), 
                    factorize = afex_options("factorize"), 
                    check_contrasts = afex_options("check_contrasts"), 
@@ -609,6 +615,8 @@ aov_ez <- function(id,
                  str_c(within, collapse = " * "), 
                  if (length(within) > 0) ")" else "", 
                  ")")
+  if (!missing(transformation))
+    dv <- paste0(transformation, "(", dv, ")")
   formula <- str_c(dv, " ~ ", rh, error)
   if (print.formula) message(str_c("Formula send to aov_car: ", formula))
   aov_car(formula = as.formula(formula), 

--- a/R/methods.afex_aov.R
+++ b/R/methods.afex_aov.R
@@ -222,13 +222,14 @@ emm_basis.afex_aov = function(object, trms, xlev, grid, ...,
                               model = afex_options("emmeans_model")) {
   model <- match.arg(model, c("univariate", "multivariate"))
   if (model == "univariate") {
-    return(emm_basis(object$aov, trms, xlev, grid, ...)  )
+    out <- emm_basis(object$aov, trms, xlev, grid, ...)
   } else if (model == "multivariate") {
     out <- emm_basis(object$lm, trms, xlev, grid, ...)
     if (length(attr(object, "within")) > 0) {
       out$misc$ylevs <- rev(attr(object, "within")) 
     }
-    return(out)
   }
+  out$misc$tran = attr(object, "transf")
+  return(out)
 }
 

--- a/man/aov_car.Rd
+++ b/man/aov_car.Rd
@@ -8,7 +8,8 @@
 \title{Convenient ANOVA estimation for factorial designs}
 \usage{
 aov_ez(id, dv, data, between = NULL, within = NULL, covariate = NULL, 
-     observed = NULL, fun_aggregate = NULL, type = afex_options("type"), 
+     observed = NULL, fun_aggregate = NULL, transformation, 
+     type = afex_options("type"), 
      factorize = afex_options("factorize"), 
      check_contrasts = afex_options("check_contrasts"), 
      return = afex_options("return_aov"), 

--- a/man/aov_car.Rd
+++ b/man/aov_car.Rd
@@ -57,6 +57,12 @@ aov_4(formula, data, observed = NULL, fun_aggregate = NULL, type = afex_options(
 
 \item{covariate}{\code{character} vector indicating the between-subject(s) covariate(s) (i.e., column(s)) in \code{data}. Default is \code{NULL} indicating no covariates.}
 
+\item{transformation}{In \code{aov_ez}, a \code{character} vector (of length
+1) indicating the name of a transformation to apply to \code{dv} before
+fitting the model. If missing, no transformation is applied. In
+\code{aov_car} and \code{aov_4}, a response transformation may be
+incorporated in the left-hand side of \code{formula}.}
+
 \item{print.formula}{\code{aov_ez} and \code{aov_4} are wrapper for \code{aov_car}. This boolean argument indicates whether the formula in the call to \code{car.aov} should be printed.}
 }
 \value{


### PR DESCRIPTION
Henrik,

I added some code to `aov_car` that supports a response transformation.  If there is a transformation, the dv is computed and renamed, and the transformation is saved as the `"transf"` attribute of the returned object. The `emm_basis` method checks for this attribute and returns it appropriately if present. Thus, the response transformation is seamlessly integrated into subsequent calls to `emmeans`, be it univariate or multivariate.

NOTE: The anova output, etc. is done for the transformed variable. The variable name used (and displayed in the summary) is composed of the transformation and the response name; e.g., `sqrt(count) ~ ...` creates a transformed response named `sqrt.count`.

I did not add this support to `aov_ez` as I'm not sure how you'd want it implemented. The most natural thing seems to be to add, say, a `transform` argument that if non-missing, would incorporate it in the formula that is passed to `aov_car`. For example, `aov_ez(dv = "yield", transform = "sqrt")` creates the formula `sqrt(yield) ~ ...`. But another option might be just to support, e.g., `dv = "sqrt(yield)"`.

Example (based on the help page):
```
data(obk.long, package = "afex")
oblog <- aov_car(log(value) ~ treatment * gender + Error(id/(phase*hour)), 
                 data = obk.long, observed = "gender")
## Contrasts set to contr.sum for the following variables: treatment, gender

ref_grid(oblog)
## 'emmGrid' object with variables:
##     treatment = control, A, B
##     gender = F, M
##     phase = fup, post, pre
##     hour = X1, X2, X3, X4, X5
## Transformation: “log” 

ref_grid(oblog, model = "mult")
## 'emmGrid' object with variables:
##     treatment = control, A, B
##     gender = F, M
##     hour = multivariate response levels: X1, X2, X3, X4, X5
##     phase = multivariate response levels: fup, post, pre
## Transformation: “log” 
```