### PR TITLE
Adds `incomplete_cases` attribute to `afex_aov` objects.

### DIFF
--- a/R/aov_car.R
+++ b/R/aov_car.R
@@ -352,6 +352,8 @@ aov_car <- function(formula,
                   "\nRemoving those cases from the analysis."), call. = FALSE) 
     tmp.dat <- tmp.dat[!missing.values,]
     data <- data[ !(data[,id] %in% missing_ids),]
+  } else {
+    missing_ids <- NULL
   }
 
   #   if (length(between) > 0) {
@@ -483,13 +485,14 @@ aov_car <- function(formula,
     attr(afex_aov, "dv") <- dv
     attr(afex_aov, "id") <- id
     attr(afex_aov, "within") <- 
-      if (length(within) > 0) lapply(data[,within, drop = FALSE], 
+      if (length(within) > 0) lapply(data[, within, drop = FALSE], 
                                      levels) else list()
     attr(afex_aov, "between") <- 
-      if (length(between) > 0) lapply(data[,between,drop=FALSE], 
+      if (length(between) > 0) lapply(data[, between, drop = FALSE], 
                                       levels) else list()
     attr(afex_aov, "type") <- type
     attr(afex_aov, "transf") <- transf
+    attr(afex_aov, "incomplete_cases") <- missing_ids
     afex_aov$anova_table <- 
       do.call("anova", 
               args = c(object = list(afex_aov), observed = list(observed), 

--- a/R/methods.afex_aov.R
+++ b/R/methods.afex_aov.R
@@ -155,6 +155,7 @@ anova.afex_aov <- function(object,
       correction else "none"
   attr(anova_table, "observed") <- 
     if(!is.null(observed) & length(observed) > 0) observed else character(0)
+  attr(anova_table, "incomplete_cases") <- attr(object, "incomplete_cases")
   attr(anova_table, "sig_symbols") <- 
     if(!is.null(sig_symbols)) sig_symbols else afex_options("sig_symbols")
   anova_table

--- a/tests/testthat/test-aov_car-structural.R
+++ b/tests/testthat/test-aov_car-structural.R
@@ -108,4 +108,12 @@ test_that("anova_table attributes", {
   obk.long <- droplevels(obk.long[obk.long$hour %in% c("1","2"),])
   two_levels_anova <- aov_ez("id", "value", obk.long, between = c("treatment"), within = c("phase", "hour"))
   expect_that(attr(two_levels_anova$anova_table, "correction"), equals("none"))
+  
+  # Test incomplete observation attribute
+  incomplete_cases <- aov_ez("id", "rt", md_12.1[-10, ], within = c("angle", "noise"))
+  
+  expect_equal(as.character(attr(incomplete_cases, "incomplete_cases")), "10")
+  expect_equal(as.character(attr(incomplete_cases$anova_table, "incomplete_cases")), "10")
+  expect_equal(as.character(attr(anova(incomplete_cases), "incomplete_cases")), "10")
+  
 })


### PR DESCRIPTION
Hi Henrik, when an ANOVA dataset contains incomplete cases, these cases are removed before the analysis and a warning is issued. I think it would be useful to additionally attach this information to the output object. This pull request adds an `incomplete_cases` attribute to `afex_aov` objects. The attribute is added to both `afex_aov` object and the `anova_table` contained therein.

Let me know what you think.