### PR TITLE
Thrown an informative error message if no random-effects terms is specified in calls to aov_4

### DIFF
--- a/R/aov_car.R
+++ b/R/aov_car.R
@@ -728,7 +728,8 @@ aov_4 <- function(formula,
                   print.formula = FALSE) {
 
   barterms <- findbars(formula)
-  if (length(barterms) > 1) stop("aov_4 only allows one random effect term")
+  if (length(barterms) > 1L) stop("aov_4 only allows one random effect term")
+  if (length(barterms) < 1L) stop("aov_4() requires one random-effect term in formula")
   within <- all.vars(barterms[[1]][[2]])
   id <- all.vars(barterms[[1]][[3]])
   

--- a/tests/testthat/test-aov_car-structural.R
+++ b/tests/testthat/test-aov_car-structural.R
@@ -144,4 +144,9 @@ test_that("error messages for common problems", {
   expect_error(
     aov_car(value ~ treatment * gender, data = obk2), 
     "formula needs an error term")
+  
+  expect_error(
+    aov_4(formula = value ~ treatment * gender, data = obk2),
+    "requires one random-effect term in formula"
+  )
 })


### PR DESCRIPTION
Hi @singmann,

this PR includes a tiny usability improvement for new users of **afex**: In our statistics classes, students rather frequently forget to provide a random-effects term in their calls to `aov_4()`. `aov_4()` now throws a hopefully-informative error message if the bar term is missing from the model specification. Hope you like the addition.

Best regards,
Marius