### PR TITLE
(incomplete) update for upcoming ggplot2 version

### DIFF
--- a/R/afex_plot_plotting_functions.R
+++ b/R/afex_plot_plotting_functions.R
@@ -203,7 +203,8 @@ interaction_plot <- function(means,
     plot_out <- plot_out + 
       ggplot2::xlab(attr(means, "x"))
   }
-  if (!missing(legend_title)) {
+  mapping <- mapping[nzchar(mapping)]
+  if (!missing(legend_title) && length(mapping) > 0) {
     legend_title <- paste(legend_title, collapse = "\n")
     tmp_list <- rep(list(ggplot2::guide_legend(title = legend_title)), 
                     length(mapping))
@@ -362,7 +363,8 @@ oneway_plot <- function(means,
     plot_out <- plot_out + 
       ggplot2::xlab(attr(means, "x"))
   }
-  if (!missing(legend_title)) {
+  mapping <- mapping[nzchar(mapping)]
+  if (!missing(legend_title) && length(mapping) > 0) {
     legend_title <- paste(legend_title, collapse = "\n")
     tmp_list <- rep(list(ggplot2::guide_legend(title = legend_title)), 
                     length(mapping))

--- a/tests/testthat/test-afex_plot-basics.R
+++ b/tests/testthat/test-afex_plot-basics.R
@@ -329,8 +329,13 @@ test_that("relabeling of factors and legend works", {
   
   p2 <- afex_plot(aw, x = "noise", trace = "angle", error = "within",
                   legend_title = "Noise Condition")
-  expect_equal(p2$guides$shape$title, "Noise Condition")
-  expect_equal(p2$guides$linetype$title, "Noise Condition")
+  if (inherits(p2$guides, "Guides")) {
+    expect_equal(p2$guides$guides$shape$params$title, "Noise Condition")
+    expect_equal(p2$guides$guides$linetype$params$title, "Noise Condition")
+  } else {
+    expect_equal(p2$guides$shape$title, "Noise Condition")
+    expect_equal(p2$guides$linetype$title, "Noise Condition")
+  }
 })
 
 test_that("connecting individual points works", {
@@ -361,8 +366,13 @@ test_that("labels are correct in case variables are of lenth > 1", {
   p2 <- afex_plot(a1, c("phase", "hour"), error = "none")
   expect_match(p1$labels$x, "phase")
   expect_match(p1$labels$x, "hour")
-  expect_match(p1$guides$shape$title, "treatment")
-  expect_match(p1$guides$shape$title, "gender")
+  if (inherits(p1$guides, "Guides")) {
+    expect_match(p1$guides$guides$shape$params$title, "treatment")
+    expect_match(p1$guides$guides$shape$params$title, "gender")
+  } else {
+    expect_match(p1$guides$shape$title, "treatment")
+    expect_match(p1$guides$shape$title, "gender")
+  }
   expect_match(p2$labels$x, "phase")
   expect_match(p2$labels$x, "hour")
 })


### PR DESCRIPTION
Hi there,

We have been preparing for a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break afex.

This PR updates some code around legends to be compatible with both the current CRAN version and the 3.5.0 release candidate of ggplot2 simultaneously. Please note that in addition to the changes proposed in this PR, there were some visual changes that you might want to inspect manually, as I lack the domain knowledge to judge their correctness. Moreover, it also seems #119 is recurring with regards to some plots in the vignettes.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help afex be ready for future changes.